### PR TITLE
enable source code generation for the protocol module

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -28,10 +28,6 @@ val protocol = project
   .settings(
     name := "$name;format="norm"$-protocol",
 
-    // The sbt-mu-srcgen plugin isn't on by default after version v0.23.x
-    // so we need to manually enable the plugin to generate mu-scala code
-    enablePlugins(SrcGenPlugin),
-
     libraryDependencies ++= Seq(
       // Needed for the generated code to compile
       "io.higherkindness" %% "mu-rpc-service" % "$mu_version$"
@@ -52,6 +48,9 @@ val protocol = project
     // Make it easy for 3rd-party clients to communicate with us via gRPC
     muSrcGenIdiomaticEndpoints := true
   )
+  // The sbt-mu-srcgen plugin isn't on by default after version v0.23.x
+  // so we need to manually enable the plugin to generate mu-scala code
+  .enablePlugins(SrcGenPlugin)
 
 val server = project
   .settings(

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -28,6 +28,10 @@ val protocol = project
   .settings(
     name := "$name;format="norm"$-protocol",
 
+    // The sbt-mu-srcgen plugin isn't on by default after version v0.23.x
+    // so we need to manually enable the plugin to generate mu-scala code
+    enablePlugins(SrcGenPlugin),
+
     libraryDependencies ++= Seq(
       // Needed for the generated code to compile
       "io.higherkindness" %% "mu-rpc-service" % "$mu_version$"


### PR DESCRIPTION
With this PR (https://github.com/higherkindness/sbt-mu-srcgen/pull/72), we'll need to update our template project to enable source code generation via sbt-mu-srcgen, since the above change makes it so the plugin is off by default.  This change makes it so that this project enables the plugin for generating source code so that the user can create a template project that demonstrates the latest (and greatest) behavior of the plugin.

Related to https://github.com/higherkindness/sbt-mu-srcgen/issues/38